### PR TITLE
Environment variable for default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ zerver -d --manifest=path/to/cache.manifest website-dir
 zerver --manifest=path/to/cache.manifest website-dir
 ```
 
+### Default options
+
+You can specify default options in an environment variable,
+to avoid having to type them every time
+```sh
+export ZERVER_FLAGS='-drl'
+```
+
 ### Cross origin
 
 Zerver can automatically make a script available to multiple host origins. This is especially useful if you are including a Zerver script from a subdomain of your webapp.

--- a/flags.js
+++ b/flags.js
@@ -1,5 +1,5 @@
-var path = require('path');
-
+var path 	   = require('path'),
+    shellParse = require('shell-quote').parse;
 
 
 var FLAG_MATCHER = /^(\w+)(?:\=(\S*))?$/,
@@ -29,10 +29,18 @@ exports.arg = function (arg, handler) {
 
 
 
-exports.run = function () {
+exports.run = function (defaultArgString) {
 	var args = 0;
 
-	process.argv.slice(2).forEach(function (arg) {
+	var defaultArgs = [];
+	if (defaultArgString) {
+		defaultArgs = shellParse(defaultArgString);
+		console.log("Environment options: " + defaultArgs.join(", "));
+	}
+	// defaults go first, so they get overriden by manually specified options
+	var argv = defaultArgs.concat(process.argv.slice(2));
+	
+	argv.forEach(function (arg) {
 		if (arg[0] !== '-') {
 			try {
 				argHandlers[args++][1](arg);

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "node" : "0.8.x"
   },
   "dependencies" : {
-    "mime"      : "1.2.7"  ,
-    "uglify-js" : "1.3.4"  ,
-    "clean-css" : "1.0.0"  ,
-    "less"      : "1.2.2"
+    "mime"        : "1.2.7"  ,
+    "uglify-js"   : "1.3.4"  ,
+    "clean-css"   : "1.0.0"  ,
+    "less"        : "1.2.2"  ,
+    "shell-quote" : "0.0.1"
   },
   "devDependencies" : {
     "stalker"   : "0.0.20" ,

--- a/run.js
+++ b/run.js
@@ -22,91 +22,6 @@ var ZERVER         = __dirname + '/zerver',
 
 
 function processFlags () {
-	var envConfig = process.env.ZERVER;
-
-	if (envConfig) {
-		var m;
-		while (m = ENV_MATCHER.exec(envConfig)) {
-			switch ( m[1] ) {
-				case 'd':
-				case 'debug':
-					if (m[2] === 'true') {
-						DEBUG = true;
-					}
-					else if (m[2] === 'false') {
-						DEBUG = false;
-					}
-					else {
-						console.warn('[WARNING] ignoring invalid env debug=' + m[2]);
-					}
-					break;
-				case 'r':
-				case 'refresh':
-					if (m[2] === 'true') {
-						REFRESH = true;
-					}
-					else if (m[2] === 'false') {
-						REFRESH = false;
-					}
-					else {
-						console.warn('[WARNING] ignoring invalid env refresh=' + m[2]);
-					}
-					break;
-				case 'l':
-				case 'logging':
-					if (m[2] === 'true') {
-						LOGGING = true;
-					}
-					else if (m[2] === 'false') {
-						LOGGING = false;
-					}
-					else {
-						console.warn('[WARNING] ignoring invalid env logging=' + m[2]);
-					}
-					break;
-				case 'b':
-				case 'verbose':
-					if (m[2] === 'true') {
-						VERBOSE = true;
-					}
-					else if (m[2] === 'false') {
-						VERBOSE = false;
-					}
-					else {
-						console.warn('[WARNING] ignoring invalid env verbose=' + m[2]);
-					}
-					break;
-				case 'p':
-				case 'production':
-					if (m[2] === 'true') {
-						PRODUCTION = true;
-					}
-					else if (m[2] === 'false') {
-						PRODUCTION = false;
-					}
-					else {
-						console.warn('[WARNING] ignoring invalid env production=' + m[2]);
-					}
-					break;
-				case 'port':
-					var envPort = parseInt( m[2] );
-					if (envPort) {
-						PORT = envPort;
-					}
-					else {
-						console.warn('[WARNING] ignoring invalid env port=' + m[2]);
-					}
-					break;
-				case 'host':
-					API_HOST = m[2];
-					break;
-				default:
-					console.warn('[WARNING] ignoring invalid env '+m[1]+'='+m[2]);
-					break;
-			}
-		}
-	}
-
 	var flags = require(__dirname + '/flags');
 
 	flags.add(['v', 'version'], function () {
@@ -168,7 +83,7 @@ function processFlags () {
 		MANIFESTS.push(manifest);
 	});
 
-	flags.run();
+	flags.run(process.env.ZERVER_FLAGS);
 
 	if (PRODUCTION) {
 		DEBUG   = false;


### PR DESCRIPTION
Instead of having a second syntax for specifying options in an environment variable, do it like this:

``` sh
ZERVER_FLAGS="-drl"
```

These are then parse as if they came before any other arguments in the command line.
